### PR TITLE
Notionプロパティ処理の簡素化

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,35 +36,14 @@ pnpm run build
 
 ### 提供されるツール
 
-#### convert_markdown_to_notion
-
-ObsidianのマークダウンをNotion互換形式に変換します。
-
-パラメータ:
-- `markdown`: 変換するマークダウンテキスト
-- `titleProperty`: タイトルとして使用するプロパティ名（オプション、デフォルト：`title`）
-
-#### build_notion_property
-
-Notion APIに送信するためのプロパティオブジェクトを構築します。
-
-パラメータ:
-- `propertyName`: プロパティ名
-- `propertyType`: プロパティタイプ（title, rich_text, date, numberなど）
-- `propertyValue`: プロパティの値
-
 #### prepare_for_notion_post
 
 マークダウンテキストを変換して、Notion APIのpost_pageに送信できる形式に整形します。
 
-パラメータ:
-- `markdown`: 変換するマークダウンテキスト
-- `pageParentId`: 親ページのID
-- `properties`: ページのプロパティ（オプション）
 
 ## サポートされているマークダウン要素
 
-- 見出し (h1-h6)
+- 見出し (h1-h3) ※h4以下の見出しはh3に変換されます
 - 段落
 - リスト（順序付き・順序なし）
 - コードブロック

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -7,62 +7,6 @@ import { buildPropertyObject } from './utils.js';
 
 // MCPサーバーにツールを登録する関数
 export function registerTools(server: McpServer): void {
-  // Obsidianマークダウンをノーション互換形式に変換するツール
-  server.tool(
-    "convert_markdown_to_notion",
-    "ObsidianのマークダウンをNotion APIと互換性のある形式に変換する",
-    { 
-      markdown: z.string().describe("変換するマークダウンテキスト"),
-      titleProperty: z.string().optional().describe("タイトルとして使用するプロパティ名")
-    },
-    ({ markdown, titleProperty = "title" }) => {
-      // フロントマターを解析
-      const { data: frontMatter, content } = matter(markdown);
-      
-      // マークダウンのパース
-      const tokens = marked.lexer(content);
-      
-      // Notionのブロック形式に変換
-      const notionBlocks = convertToNotionBlocks(tokens);
-      
-      // 最初の見出しや段落をタイトルとして使用
-      let title = "無題のページ";
-      // フロントマターにタイトルがあればそれを使用
-      if (frontMatter && frontMatter.title) {
-        title = frontMatter.title;
-      } else {
-        // フロントマターになければコンテンツから探す
-        for (const token of tokens) {
-          if ((token as any).type === 'heading' || (token as any).type === 'paragraph') {
-            title = (token as any).text;
-            break;
-          }
-        }
-      }
-      
-      // フロントマターのプロパティを追加
-      const properties = {
-        [titleProperty]: title,
-        ...frontMatter
-      };
-      
-      const result = {
-        title,
-        blocks: notionBlocks,
-        properties
-      };
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(result, null, 2)
-          }
-        ]
-      };
-    }
-  );
-
   // マークダウンテキストを更新してNotion post_pageに送信するツール
   server.tool(
     "prepare_for_notion_post",


### PR DESCRIPTION
- **docs: READMEから不要なツール説明を削除**
- **refactor: convert_markdown_to_notionツールを削除**
- **refactor: プロパティ処理ロジックを簡略化**
